### PR TITLE
Термінологія: instance

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -50,6 +50,7 @@
 | hook | хук *(з маленької літери)* |
 | incapsulation | інкапсуляція |
 | incapsulated | інкапсульований |
+| instance | екземпляр |
 | key | ключ |
 | lazy initialization | ледача ініціалізація |
 | library | бібліотека |


### PR DESCRIPTION
Пропоную додати переклад для слова `instance`. Серед технічних джерел українською мовою я зустріла два варіанти перекладу його - як `екземпляр` та як `примірник`. І хоча екземпляр може мати відтінок російської кальки, про те саме такий переклад вживається в MDN (для прикладу, тут https://developer.mozilla.org/uk/docs/Web/JavaScript/Reference/Classes) 