### PR TITLE
Quick Fix: Translate 'Languages'

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -209,7 +209,7 @@ const Header = ({location}: {location: Location}) => (
                   display: 'none',
                 },
               }}>
-              Languages
+              Переклади
             </span>
           </Link>
           <a


### PR DESCRIPTION
Translate "Languages" in the header.