### PR TITLE
Using search index for Ukrainian content

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -23,7 +23,7 @@ class DocSearch extends Component<{}, State> {
     if (window.docsearch) {
       window.docsearch({
         apiKey: 'b9c27b5e1b641fe4e13bf9fdd476f49a',
-        indexName: 'react',
+        indexName: 'reactjs_uk',
         inputSelector: '#algolia-doc-search',
       });
     } else {


### PR DESCRIPTION
I've noticed that search was broken. 
Error code suggested that different index needs to be used.

**[Before](http://uk.reactjs.org):**
<img width="400" alt="Screenshot 2019-04-21 at 14 34 25" src="https://user-images.githubusercontent.com/3315896/56470827-c4918100-6442-11e9-9ef9-88ec6f07f77a.png">
Response from Algolia:
```JSON
{"message":"Index not allowed with this API key","status":403}
```

**[After](https://deploy-preview-113--uk-reactjs.netlify.com):**
<img width="400" alt="Screenshot 2019-04-21 at 14 33 56" src="https://user-images.githubusercontent.com/3315896/56470846-f7d41000-6442-11e9-8b23-31065b62636e.png">

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->